### PR TITLE
refactor: Remove operator lib continues code generation, move it to init command

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -122,8 +122,8 @@ pub enum Commands {
     /// Generate Kubernetes operator code from an OpenAPI specification.
     ///
     /// This command generates various components of a Kubernetes operator project
-    /// including library files, manifests, controllers, and types based on the
-    /// OpenAPI specification provided.
+    /// including manifests, controllers, and types based on the OpenAPI
+    /// specification provided.
     #[command(about = "Generate Kubernetes operator code from an OpenAPI specification")]
     Generate {
         /// Path to the OpenAPI specification file.
@@ -135,9 +135,6 @@ pub enum Commands {
         /// Generate all code.
         #[arg(short, long, help = "Generate all code")]
         all: bool,
-        /// Generate the lib.rs file.
-        #[arg(short, long, help = "Generate the lib.rs file")]
-        lib: bool,
         /// Generate the manifests.
         #[arg(short, long, help = "Generate the manifests")]
         manifests: bool,

--- a/cli/src/commands/generate.rs
+++ b/cli/src/commands/generate.rs
@@ -7,7 +7,7 @@ use crate::templates::{
         rbac::{ClusterRole, ClusterRoleBinding, Role, RoleBinding, ServiceAccount},
     },
     operator::{
-        Controller, ControllerActionDelete, ControllerActionPost, ControllerActionPut, Lib, Main,
+        Controller, ControllerActionDelete, ControllerActionPost, ControllerActionPut, Main,
         Type as TypeTemplate,
     },
     ClusterRoleTemplateIdentifiers, ControllerAttributes, Field, Metadata, Resource,
@@ -58,7 +58,6 @@ pub fn execute(
     base_path: &String,
     openapi_file: &String,
     all: &bool,
-    lib: &bool,
     manifests: &bool,
     controllers: &bool,
     types: &bool,
@@ -107,9 +106,8 @@ pub fn execute(
     let k8s_manifests_operator_dir = format!("{}/manifests/operator", base_path);
     let k8s_manifests_examples_dir = format!("{}/manifests/examples", base_path);
 
-    if *all || (!*lib && !*manifests && !*controllers && !*types) {
-        info!("Generating all...");
-        generate_lib(&k8s_operator_dir)?;
+    if *all || (!*manifests && !*controllers && !*types) {
+        info!("Generating all manifests, controllers and types...");
         generate_types(
             &k8s_operator_types_dir,
             &schemas,
@@ -146,10 +144,6 @@ pub fn execute(
             &kubernetes_operator_resource_ref.clone(),
         )?;
         return Ok(());
-    }
-    if *lib {
-        info!("Generating lib...");
-        generate_lib(&k8s_operator_dir)?;
     }
     if *manifests {
         info!("Generating manifests...");
@@ -598,20 +592,6 @@ fn generate_type(
 
     let base_path: &Path = Path::new(directory);
     let file_name: String = format!("{}.rs", arg_name_clone);
-    write_to_file(base_path, &file_name, content)?;
-    format_file(base_path.join(file_name).to_str().unwrap())
-}
-
-fn generate_lib(directory: &str) -> Result<(), AppError> {
-    let file_path = format!("{}/src/lib.rs", directory);
-    if get_ignored_files()?.contains(&file_path) {
-        return Ok(());
-    }
-
-    let content: String = Lib {}.render()?;
-
-    let base_path: &Path = &Path::new(directory).join("src");
-    let file_name: String = "lib.rs".to_string();
     write_to_file(base_path, &file_name, content)?;
     format_file(base_path.join(file_name).to_str().unwrap())
 }

--- a/cli/src/commands/init.rs
+++ b/cli/src/commands/init.rs
@@ -4,13 +4,13 @@ use crate::templates::general::{
     CargoConfig, ClusterYaml, Dockerfile, Dockerignore, Editorconfig, EnvExample, GitAttributes,
     GitIgnore, Prettierrc, ReadmeMd, RustfmtToml, Taskfile,
 };
-use crate::templates::operator::Cli;
 use crate::templates::{
     cargo::{CargoToml, CrdgenCargoToml, OperatorCargoToml, TestsCargoToml},
     crdgen::Main as CrdgenMain,
     devcontainer::{Deps, Json, LaunchJsonExample, SetupGit, Zshrc},
     general::OpenAPIGeneratorIgnore,
     operator::Main as OperatorMain,
+    operator::{Cli, Lib},
     tests::{Main as TestsMain, UtilsClient, UtilsCluster, UtilsOperator},
 };
 use crate::utils::{
@@ -122,6 +122,11 @@ pub fn execute(conf: Config, path: &String) -> Result<(), AppError> {
     let project_name: String = conf.operator_name.clone();
 
     // Generate operator files
+    generate_template_file(
+        Lib {},
+        base_path.join(K8S_OPERATOR_DIR).join("src").as_path(),
+        "lib.rs",
+    )?;
     generate_template_file(
         Cli {
             project_name: project_name.clone(),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -33,20 +33,11 @@ fn main() -> Result<(), AppError> {
             openapi_file,
             path,
             all,
-            lib,
             manifests,
             controllers,
             types,
         }) => {
-            commands::generate::execute(
-                path,
-                openapi_file,
-                all,
-                lib,
-                manifests,
-                controllers,
-                types,
-            )?;
+            commands::generate::execute(path, openapi_file, all, manifests, controllers, types)?;
         }
         None => {
             info!("No command provided");

--- a/cli/tests/unit/generate_command.rs
+++ b/cli/tests/unit/generate_command.rs
@@ -13,8 +13,8 @@ mod tests {
     use tempfile::tempdir;
 
     /// Helper function to set common parameters for `execute`.
-    fn default_params() -> (bool, bool, bool, bool, bool) {
-        (true, false, false, false, false)
+    fn default_params() -> (bool, bool, bool, bool) {
+        (true, false, false, false)
     }
 
     /// Tests that `execute` fails when the Kubernetes extension is missing from the OpenAPI spec.
@@ -32,13 +32,12 @@ components:
 "#;
 
         let (dir, openapi_file) = create_temp_file("openapi.yaml", openapi_yaml);
-        let (all, lib, manifests, controllers, types) = default_params();
+        let (all, manifests, controllers, types) = default_params();
 
         let result = execute(
             &dir.path().to_string_lossy().to_string(),
             &openapi_file,
             &all,
-            &lib,
             &manifests,
             &controllers,
             &types,
@@ -68,13 +67,12 @@ components:
         let dir = tempdir()?;
         let openapi_file = dir.path().join("missing_openapi.yaml");
 
-        let (all, lib, manifests, controllers, types) = default_params();
+        let (all, manifests, controllers, types) = default_params();
 
         let result = execute(
             &dir.path().to_string_lossy().to_string(),
             &openapi_file.to_string_lossy().to_string(),
             &all,
-            &lib,
             &manifests,
             &controllers,
             &types,
@@ -96,13 +94,12 @@ components:
 invalid_yaml: [unclosed_list
 "#;
         let (dir, openapi_file) = create_temp_file("invalid_openapi.yaml", openapi_yaml);
-        let (all, lib, manifests, controllers, types) = default_params();
+        let (all, manifests, controllers, types) = default_params();
 
         let result = execute(
             &dir.path().to_string_lossy().to_string(),
             &openapi_file,
             &all,
-            &lib,
             &manifests,
             &controllers,
             &types,


### PR DESCRIPTION
## Summary

Remove operator lib continues code generation, move it to init command.

Lib should by design contain generic functions without the specifics.
