### PR TITLE
fix: Replace `dotenv` with `dotenvy` to address security advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,10 +239,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
+name = "dotenvy"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "downcast"
@@ -464,7 +464,7 @@ dependencies = [
  "askama",
  "assert_cmd",
  "clap",
- "dotenv",
+ "dotenvy",
  "env_logger",
  "indexmap",
  "insta",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,9 +17,9 @@ askama = "0.12.1"
 log = "0.4.17"
 env_logger = "0.11.3"
 clap = { version = "4.5.4", features = ["cargo", "derive", "env"] }
-dotenv = "0.15.0"
 indexmap = { version = "2.6.0", features = ["serde"] }
 thiserror = "2.0.3"
+dotenvy = "0.15.7"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,4 +1,4 @@
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use std::env;
 
 use crate::{cli::Cli, errors::AppError};

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -11,10 +11,11 @@ use crate::{
     errors::AppError,
 };
 use clap::Parser;
+use dotenvy::dotenv;
 use log::{debug, info};
 
 fn main() -> Result<(), AppError> {
-    dotenv::dotenv().ok();
+    dotenv().ok();
     env_logger::init();
 
     let cli = Cli::parse();


### PR DESCRIPTION
## Summary

The update replaces the unmaintained `dotenv` crate with `dotenvy` to resolve the security advisory.

Closes #22.