### PR TITLE
Add JSON support for OpenAPI spec hydration and error handling

### DIFF
--- a/cli/src/commands/hydrate.rs
+++ b/cli/src/commands/hydrate.rs
@@ -82,7 +82,14 @@ pub fn execute(conf: Config, openapi_file: &String) -> Result<(), AppError> {
         }
     }
 
-    fs::write(openapi_file, serde_yaml::to_string(&openapi)?)?;
+    let output_content = if openapi_file.ends_with(".json") {
+        serde_json::to_string_pretty(&openapi)?
+    } else {
+        serde_yaml::to_string(&openapi)?
+        // TODO - add formatting, because serde_yaml::to_string_pretty(&openapi)? is not implemented
+    };
+
+    fs::write(openapi_file, output_content)?;
 
     info!("OpenAPI spec hydrated successfully");
 

--- a/cli/src/errors.rs
+++ b/cli/src/errors.rs
@@ -17,6 +17,9 @@ pub enum AppError {
     #[error("JSON deserialization error: {0}")]
     JsonError(#[from] JsonError),
 
+    #[error("Unsupported format: {0}")]
+    UnsupportedFormat(String),
+
     #[error("Askama template error: {0}")]
     AskamaError(#[from] AskamaError),
 

--- a/cli/src/errors.rs
+++ b/cli/src/errors.rs
@@ -1,4 +1,5 @@
 use askama::Error as AskamaError;
+use serde_json::Error as JsonError;
 use serde_yaml::Error as YamlError;
 use thiserror::Error;
 
@@ -12,6 +13,9 @@ pub enum AppError {
 
     #[error("YAML deserialization error: {0}")]
     YamlError(#[from] YamlError),
+
+    #[error("JSON deserialization error: {0}")]
+    JsonError(#[from] JsonError),
 
     #[error("Askama template error: {0}")]
     AskamaError(#[from] AskamaError),

--- a/cli/tests/unit/generate_command.rs
+++ b/cli/tests/unit/generate_command.rs
@@ -202,15 +202,15 @@ components:
                 "properties": {
                     "id": {
                         "type": "integer",
-                        "format": "int64",
+                        "format": "int64"
                     },
                     "name": {
-                        "type": "string",
+                        "type": "string"
                     },
                     "email": {
                         "type": "string",
-                        "format": "email",
-                    },
+                        "format": "email"
+                    }
                 },
                 "required": ["id"]
             }

--- a/cli/tests/utils/mod.rs
+++ b/cli/tests/utils/mod.rs
@@ -20,7 +20,6 @@ pub enum SpecValue {
 }
 
 /// This function is used to read the content of a temporary file
-#[allow(dead_code)]
 pub fn read_temp_file(file_path: &str) -> Result<SpecValue, AppError> {
     let hydrated_spec_content = std::fs::read_to_string(file_path)?;
 

--- a/cli/tests/utils/mod.rs
+++ b/cli/tests/utils/mod.rs
@@ -1,10 +1,11 @@
 use kopgen::errors::AppError;
+use serde_json::Value as JsonValue;
 use serde_yaml::Value as YamlValue;
 use std::fs::File;
 use std::io::Write;
 use tempfile::TempDir;
 
-// This function is used to create a temporary file with the provided content
+/// This function is used to create a temporary file with the provided content
 pub fn create_temp_file(file_name: &str, content: &str) -> (TempDir, String) {
     let dir: TempDir = TempDir::new().unwrap();
     let file_path = dir.path().join(file_name);
@@ -13,9 +14,30 @@ pub fn create_temp_file(file_name: &str, content: &str) -> (TempDir, String) {
     (dir, file_path.to_string_lossy().to_string())
 }
 
-// This function is used to read the content of a temporary file
+pub enum SpecValue {
+    Yaml(YamlValue),
+    Json(JsonValue),
+}
+
+/// This function is used to read the content of a temporary file
 #[allow(dead_code)]
-pub fn read_temp_file(file_path: &str) -> Result<YamlValue, AppError> {
+pub fn read_temp_file(file_path: &str) -> Result<SpecValue, AppError> {
     let hydrated_spec_content = std::fs::read_to_string(file_path)?;
-    Ok(serde_yaml::from_str(&hydrated_spec_content)?)
+
+    if file_path.ends_with(".yaml") || file_path.ends_with(".yml") {
+        let yaml = serde_yaml::from_str(&hydrated_spec_content)?;
+        Ok(SpecValue::Yaml(yaml))
+    } else if file_path.ends_with(".json") {
+        let json = serde_json::from_str(&hydrated_spec_content)?;
+        Ok(SpecValue::Json(json))
+    } else {
+        // Attempt to parse as YAML, fallback to JSON
+        match serde_yaml::from_str(&hydrated_spec_content) {
+            Ok(yaml) => Ok(SpecValue::Yaml(yaml)),
+            Err(_) => {
+                let json = serde_json::from_str(&hydrated_spec_content)?;
+                Ok(SpecValue::Json(json))
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Introduce JSON serialization and deserialization for OpenAPI specifications, enhancing error handling for JSON-related issues. Update the hydration process to support both JSON and YAML formats.