### PR TITLE
fix: RUST_LOG defaulting to error

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -15,6 +15,26 @@ pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Commands>,
 
+    /// The log level for the application.
+    /// Example: debug, info, warn, error
+    /// Default: info
+    /// This is the log level that the application will use to output log messages.
+    /// The log level can be set using the RUST_LOG environment variable.
+    /// Example: RUST_LOG=debug kopgen
+    /// Example: RUST_LOG=info kopgen
+    /// Example: RUST_LOG=warn kopgen
+    /// Example: RUST_LOG=error kopgen
+    /// Example: kopgen --verbosity debug
+    /// Example: kopgen -v info
+    #[arg(
+        long,
+        short,
+        env = "RUST_LOG",
+        default_value = "info",
+        help = "Set the log level for the application"
+    )]
+    pub verbosity: String,
+
     /// The name of the kubernetes operator.
     /// Example: Cats Operator
     /// Default: Example Operator

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -21,6 +21,10 @@ fn main() -> Result<(), AppError> {
     let cli = Cli::parse();
     let conf = Config::load_from_cli(&cli)?;
 
+    if std::env::var("RUST_LOG").is_err() {
+        std::env::set_var("RUST_LOG", "info");
+    }
+
     debug!("{:?}", conf);
 
     match &cli.command {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -16,7 +16,6 @@ use log::{debug, info};
 
 fn main() -> Result<(), AppError> {
     dotenv().ok();
-    env_logger::init();
 
     let cli = Cli::parse();
     let conf = Config::load_from_cli(&cli)?;
@@ -25,7 +24,17 @@ fn main() -> Result<(), AppError> {
         std::env::set_var("RUST_LOG", "info");
     }
 
-    debug!("{:?}", conf);
+    if cli.verbosity != "info" {
+        std::env::remove_var("RUST_LOG");
+        std::env::set_var("RUST_LOG", &cli.verbosity);
+    }
+
+    env_logger::init();
+
+    debug!(
+        "Running in debug mode. These are the configurations:\n {:#?}",
+        conf
+    );
 
     match &cli.command {
         Some(Commands::Init { path }) => {


### PR DESCRIPTION
## Summary

This pull request introduces a new feature to the CLI application, allowing users to set the log level via a command-line argument or environment variable. The most important changes include adding a new `verbosity` argument to the `Cli` struct and updating the `main` function to handle this new argument.

Enhancements to CLI logging:

* [`cli/src/cli.rs`](diffhunk://#diff-ac22ed996b15b25355a0d73a66f3ce665736852cd8a7c2439a10bc2edea22000R18-R37): Added a `verbosity` argument to the `Cli` struct, allowing users to set the log level for the application using either a command-line argument or the `RUST_LOG` environment variable.
* [`cli/src/main.rs`](diffhunk://#diff-37970e7d817d4316a093bb967d74ff7e26d9c6c01d93f5a79d3d195ba9f6155bL19-R37): Modified the `main` function to check for the `RUST_LOG` environment variable and set the log level based on the new `verbosity` argument from the CLI. This ensures that the correct log level is used when the application runs.

- Closes #41 